### PR TITLE
fix: brodcastListeningAddress タイポを broadcastListeningAddress に修正

### DIFF
--- a/.changeset/fix-typo-broadcast.md
+++ b/.changeset/fix-typo-broadcast.md
@@ -3,3 +3,5 @@
 ---
 
 BREAKING CHANGE: `TCNetConfiguration.brodcastListeningAddress` を `broadcastListeningAddress` にリネーム (タイポ修正)
+
+`broadcastListeningAddress` のデフォルト値を `broadcastAddress` から `"0.0.0.0"` に変更

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -23,7 +23,6 @@ console.log(`Connecting to TCNet on ${INTERFACE}`);
 const config = new TCNetConfiguration();
 
 config.broadcastInterface = INTERFACE;
-config.broadcastListeningAddress = "0.0.0.0";
 
 const client = new TCNetClient(config);
 

--- a/src/tcnet.ts
+++ b/src/tcnet.ts
@@ -59,7 +59,7 @@ export class TCNetClient extends EventEmitter {
         if (this.config.broadcastInterface && this.config.broadcastAddress == "255.255.255.255") {
             this.config.broadcastAddress = interfaceAddress(this.config.broadcastInterface);
         }
-        this.config.broadcastListeningAddress ||= this.config.broadcastAddress;
+        this.config.broadcastListeningAddress ||= "0.0.0.0";
     }
 
     public get log(): TCNetLogger | null {


### PR DESCRIPTION
## Summary

- `TCNetConfiguration.brodcastListeningAddress` のタイポを `broadcastListeningAddress` に修正
- BREAKING CHANGE: public APIのプロパティ名変更

Closes #3

## Test plan

- [x] `npm run build` 成功
- [x] `grep -r "brodcast" src/ examples/` でタイポ残存なし
- [x] 実機テスト: Bridge (BRIDGE71) への接続・メタデータ取得を確認