### PR TITLE
fix(ci): OIDC Trusted Publishing のための changeset config 修正

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
     "commit": false,
     "fixed": [],
     "linked": [],
-    "access": "restricted",
+    "access": "public",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
     "ignore": []


### PR DESCRIPTION
## Summary

- `.changeset/config.json` の `access` を `restricted` → `public` に修正
- `package.json` の `publishConfig.access: "public"` との整合性を確保

## OIDC Trusted Publishing 対応

NPM_TOKEN による認証ではなく、npm OIDC Trusted Publishing を採用する。
ワークフロー側は既に対応済み（`id-token: write`、`publishConfig.provenance: true`）。

### PR マージ後の手動作業

npmjs.com で Trusted Publisher を登録する（1回のみ）:

1. https://www.npmjs.com/package/@9c5s/node-tcnet/access にアクセス
2. Trusted Publisher セクションで GitHub Actions を選択
3. 以下を入力:
   - Organization: `9c5s`
   - Repository: `node-tcnet`
   - Workflow filename: `release-and-publish.yaml`
   - Environment name: `main`

Closes #11