### PR TITLE
feat: commitlintにscope-emptyルールを追加

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -2,5 +2,6 @@ export default {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "subject-case": [0],
+    "scope-empty": [2, "always"],
   },
 };


### PR DESCRIPTION
## Summary
- commitlintに`scope-empty: [2, "always"]`ルールを追加し、scope付きコミットメッセージ(例: `refactor(test):`)をエラーにする

## Test plan
- [x] scope付きメッセージ(`refactor(test): テスト`)がcommitlintでエラーになることを確認
- [x] scope無しメッセージ(`refactor: テスト`)が正常通過することを確認
- [x] pre-commit/commit-msgフックが正常動作することを確認

Closes #20