### PR TITLE
fix: pitchBendを符号付き16bitで読み取る

### DIFF
--- a/.changeset/fix-pitch-bend-signed.md
+++ b/.changeset/fix-pitch-bend-signed.md
@@ -1,0 +1,7 @@
+---
+"@9c5s/node-tcnet": patch
+---
+
+pitchBendを符号付き16bitで読み取るよう修正
+
+`readUInt16LE`を`readInt16LE`に変更し、負のピッチ値が正しく負の数値として返されるようにした。

--- a/src/network.ts
+++ b/src/network.ts
@@ -574,7 +574,7 @@ export class TCNetDataPacketMetrics extends TCNetDataPacket {
             speed: this.buffer.readUInt32LE(40),
             beatNumber: this.buffer.readUInt32LE(57),
             bpm: this.buffer.readUInt32LE(112),
-            pitchBend: this.buffer.readUInt16LE(116),
+            pitchBend: this.buffer.readInt16LE(116),
             trackID: this.buffer.readUInt32LE(118),
         };
     }

--- a/tests/packet-parsers.test.ts
+++ b/tests/packet-parsers.test.ts
@@ -544,7 +544,7 @@ describe("TCNetDataPacketMetrics", () => {
         buffer.writeUInt32LE(100000, 40); // speed
         buffer.writeUInt32LE(4, 57); // beatNumber
         buffer.writeUInt32LE(14000, 112); // bpm (= 140.00 BPM * 100)
-        buffer.writeUInt16LE(40000, 116); // pitchBend (32768=100%)
+        buffer.writeInt16LE(600, 116); // pitchBend (+6.00%)
         buffer.writeUInt32LE(777, 118); // trackID
 
         const packet = new TCNetDataPacketMetrics();
@@ -564,7 +564,7 @@ describe("TCNetDataPacketMetrics", () => {
         expect(packet.data!.speed).toBe(100000);
         expect(packet.data!.beatNumber).toBe(4);
         expect(packet.data!.bpm).toBe(14000);
-        expect(packet.data!.pitchBend).toBe(40000);
+        expect(packet.data!.pitchBend).toBe(600);
         expect(packet.data!.trackID).toBe(777);
     });
 
@@ -580,9 +580,11 @@ describe("TCNetDataPacketMetrics", () => {
     });
 
     it.each([
-        { value: 0, label: "最小値" },
-        { value: 32768, label: "100%基準" },
-        { value: 65535, label: "最大値" },
+        { value: 0, label: "ピッチ変更なし" },
+        { value: 600, label: "+6.00%" },
+        { value: -600, label: "-6.00%" },
+        { value: 32767, label: "最大値" },
+        { value: -32768, label: "最小値" },
     ])("pitchBend=$value ($label) を正しくパースする", ({ value }) => {
         const buffer = Buffer.alloc(122);
         buffer.writeUInt8(3, 2);
@@ -590,7 +592,7 @@ describe("TCNetDataPacketMetrics", () => {
         buffer.writeUInt8(200, 7);
         buffer.writeUInt8(2, 24);
         buffer.writeUInt8(1, 25);
-        buffer.writeUInt16LE(value, 116);
+        buffer.writeInt16LE(value, 116);
         const packet = new TCNetDataPacketMetrics();
         packet.buffer = buffer;
         packet.header = createHeader(buffer);


### PR DESCRIPTION
## Summary

- MetricsパケットのpitchBendフィールドを`readUInt16LE`から`readInt16LE`に変更
- 負のピッチ値 (速度低下方向) が正しく負の数値として返されるようにする

## 問題

pitchBendが符号なし16bitで読み取られていたため、負のピッチ値が不正な大きな正の値として返されていた。

例: ピッチ-10.00%のとき、期待値`-1000`に対して`64536`が返されていた。

| speed | pitch (旧) | pitch (修正後) |
|-------|-----------|--------------|
| 0 | 555.36% | -100.00% |
| 90 | 645.36% | -10.00% |
| 100 | 0.00% | 0.00% |
| 110 | 10.00% | 10.00% |

## Test plan

- [x] 既存テストの期待値を符号付きに修正
- [x] 正値・負値・境界値 (0, ±600, 32767, -32768) のパラメタライズドテストで検証
- [x] 278テスト全PASS